### PR TITLE
Avoided repeatedly freeing slide on exit.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     int displayInitialized = 0;
 
     //0-exit, 1-open new file
-    int returnCode; 
+    int returnCode = 0; 
     do
     {
         // if opening new file, reset vars from last loop

--- a/src/slides.c
+++ b/src/slides.c
@@ -37,10 +37,11 @@ line *nextLine(line *prev) {
 
 void freeSlides(slide *s) {
     slide *next;
-    while (next!=NULL) {
+    while (s) {
         next = s->next;
         memset(s, 0, sizeof(*s));
         free(s);
+        s = next;
     }
 }
 


### PR DESCRIPTION
Previously, when dss was exiting, it would call `freeSlides` and attempt to repeatedly free the slide that was passed in rather than iterating over the linked list of slides freeing each.  When there was more than one slide, the consequence was attempting to free unallocated memory, resulting in a crash and the following being displayed in the terminal after exiting:

    dss(78256,0x114a565c0) malloc: *** error for object 0x7fd62a502700:
    pointer being freed was not allocated
    dss(78256,0x114a565c0) malloc: *** set a breakpoint in
    malloc_error_break to debug

Here, that behavior is corrected, and each slide in the linked list is freed.  As a result, dss exits cleanly.