### PR TITLE
Dynamically sized lines and links.

### DIFF
--- a/include/mdlink.h
+++ b/include/mdlink.h
@@ -4,13 +4,28 @@
 typedef struct mdlink
 {
     int index;
-    char title[256];
-    char url[1000];
     struct mdlink *next;
+    int __urlOffset;
+    char __storage[];
 } mdlink;
 
-mdlink *newLink();
-mdlink *appendLink(mdlink *first);
+mdlink *newLink(char *title, size_t titleLength, char *url, size_t urlLength);
 void freeLinks(mdlink *first);
+
+static inline
+__attribute__((always_inline))
+char *
+linkGetTitle(mdlink *link) 
+{
+    return link->__storage;
+}
+
+static inline
+__attribute__((always_inline))
+char *
+linkGetURL(mdlink *link) 
+{
+    return link->__storage + link->__urlOffset;
+}
 
 #endif

--- a/include/slides.h
+++ b/include/slides.h
@@ -15,16 +15,16 @@ typedef struct slide
 } slide;
 
 typedef struct line {
-    char content[256]; // todo can this be dynamic?
     int colorPair;
     struct line *prev;
     struct line *next;
+    size_t contentLength;
+    char content[];
 } line;
 
 slide *newSlide();
 slide *nextSlide(slide *prev);
-line *newLine();
-line *nextLine(line *prev);
+line *newLine(char *buffer, size_t length);
 void freeSlides(slide *s);
 void freeLines(line *first);
 

--- a/src/display.c
+++ b/src/display.c
@@ -455,7 +455,7 @@ slide* searchLastInput(int direction, slide* curSlide) {
     slide *searching;
     line *toSearch;
     if (direction==1) {
-        if (!curSlide->next==NULL) {
+        if (curSlide->next) {
             searching = curSlide->next;
             toSearch = searching->first;
         } else {
@@ -464,7 +464,7 @@ slide* searchLastInput(int direction, slide* curSlide) {
             return curSlide;
         }
     } else {
-        if (!curSlide->prev==NULL) {
+        if (curSlide->prev) {
             searching = curSlide->prev;
             toSearch = searching->first;
         } else {
@@ -515,12 +515,12 @@ slide* handleKeyPress(slide *curSlide)
         case 'j':
         case 'J':
         case ' ': // next slide
-            if (!curSlide->next==NULL)
+            if (curSlide->next)
                 curSlide = curSlide->next;
             break;
         case 'k':
         case 'K': // prev slide
-            if (!curSlide->prev==NULL)
+            if (curSlide->prev)
                 curSlide = curSlide->prev;
             break;
         case '9':

--- a/src/display.c
+++ b/src/display.c
@@ -249,7 +249,7 @@ void printLinksOnSlide(slide *curSlide) {
     int i = 2; //start line to print at
     while (l) {
         move(i, 0);
-        printw("%d - %s",l->index, l->url);
+        printw("%d - %s",l->index, linkGetURL(l));
         l = l->next;
         i++;
     }
@@ -260,13 +260,12 @@ void openLinkAtIndex(int index, slide *curSlide) {
     while (l) {
         if (index == l->index) {
             // build a command that will open link in def browser
-            char systemCommand[1000] = {0};
-            strcat(systemCommand, "xdg-open ");
-            strcat(systemCommand, l->url);
             // send any output to /dev/null (instead of stdout)
-            strcat(systemCommand, " >/dev/null 2>&1");
+            char *systemCommand = NULL;
+            asprintf(&systemCommand, "xdg-open %s >/dev/null 2>&1", linkGetURL(l));
             // if the command fails, display a soft error
             system(systemCommand);
+            free(systemCommand);
             return;
         } else {
             l = l->next;

--- a/src/mdlink.c
+++ b/src/mdlink.c
@@ -4,33 +4,17 @@
 #include "mdlink.h"
 
 
-mdlink *newLink() {
+mdlink *newLink(char *title, size_t titleLength, char *url, size_t urlLength) {
     mdlink *l;
-    l = malloc(sizeof(mdlink));
-    memset(l, 0, sizeof(*l));
+    l = malloc(sizeof(mdlink) + sizeof(char) * (titleLength + urlLength + 3));
     l->index = 0;
     l->next = NULL;
+    strncpy(l->__storage, title, titleLength);
+    l->__storage[titleLength] = '\0';
+    strncpy(l->__storage + titleLength + 1, url, urlLength);
+    l->__urlOffset = titleLength + 1;
+    l->__storage[titleLength + urlLength + 2] = '\0';
     return l;
-}
-
-mdlink *nextLink(mdlink *prev) {
-    mdlink *n;
-    n = malloc(sizeof(mdlink));
-    memset(n, 0, sizeof(*n));
-    prev->next = n;
-    n->index = prev->index+1;
-    n->next = NULL;
-    return n;
-}
-
-mdlink *appendLink(mdlink *first) {
-    mdlink *l = first;
-    mdlink *next = first->next;
-    while (next) {
-        l = next;
-        next = l->next;
-    }
-    return nextLink(l);
 }
 
 void freeLinks(mdlink *l) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -129,8 +129,8 @@ void handleMarkdownStyleLink(char *buf, slide *s) {
             size_t urlLength;
             bool shouldFreeURL;
             // make sure that http in url before assigning as value to struct
-            if (strnstr(urlStart, "http://", parsedURLLength) || 
-                strnstr(urlStart, "https://", parsedURLLength)) {
+            if ((parsedURLLength > 7 /*strlen("http://")*/ && memcmp(urlStart, "http://", 7) == 0) ||
+                (parsedURLLength > 8 /*strlen("https://")*/ && memcmp(urlStart, "https://", 8) == 0)) {
                 url = urlStart;
                 urlLength = parsedURLLength;
                 shouldFreeURL = false;

--- a/src/slides.c
+++ b/src/slides.c
@@ -20,19 +20,15 @@ slide *nextSlide(slide *prev) {
     return n;
 }
 
-line *newLine() {
-    line *l = malloc(sizeof(line));
-    memset(l, 0, sizeof(*l));
+line *newLine(char *buffer, size_t length) {
+    line *l = malloc(sizeof(line) + sizeof(char) * length);
+    l->colorPair = 0;
+    l->prev = NULL;
+    l->next = NULL;
+    l->contentLength = length;
+    strncpy(l->content, buffer, length);
+    l->content[length - 1] = '\0';
     return l;
-}
-
-line *nextLine(line *prev) {
-    line *n = malloc(sizeof(line));
-    memset(n, 0, sizeof(*n));
-    n->prev = prev;
-    prev->next = n;
-    n->next = NULL;
-    return n;
 }
 
 void freeSlides(slide *s) {


### PR DESCRIPTION
Previously, lines and links had fixed length buffers.  For small lines and links, that was wasteful.  For extremely long lines and links, that was responsible for crashes.

Now, the structs for both line and link structs have flexible array members to enable variable length contents.  Since the link struct has two variable length strings, its flexible array member is used to store both.  To facilitate accessing the two strings, the struct now has two functions associated with it `linkGetTitle` and `linkGetURL`.

Since the size of the contents of the line and link structs must now be known before allocating the structs which store them, the code which constructs each had to be reordered to determine the contents first and then construct the struct instances with those contents.

Similarly, the parsing functions have been modified to use a single variable sized array for the line, enabled by using `getline` rather than `fgets`.  This single buffer is used not just by `parseTXT` but also by `handleMarkdownStyleLink` which no longer copies the title and url from the line but instead uses pointers into the buffer and lengths in order to construct the `mdlink` struct.