### PR TITLE
Termux Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ all: dss
 dss: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o dss $(LDFLAGS)
 
+anew: clean all
+
 tidy:
 	$(RM) *.o
 	$(RM) src/*.o

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@ void version() {
 int main(int argc, char *argv[])
 {	
     // parse flags
-    char ch;
+    int ch; // must be int: comparing char to EOF always returns true
     while ((ch=getopt(argc, argv, "hv"))!=EOF) {
         switch (ch)
         {
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
     }
-    argv += optind;
+    argv += optind; // optind is the offset of the first non-option arg
 
     if (argc == 1) {
         /* no args (other than options) */


### PR DESCRIPTION
Not sure about amd64, but on Termux (aarch64, in my case) comparing a `char` with a constant like `EOF` always evaluates to true, causing an infinite loop.

(Addresses #48)